### PR TITLE
Run rabbitmq container with default rabbitmq UID and GID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   rabbitmq:
     image: rabbitmq:${RABBITMQ_VERSION:-3.12-management}
     container_name: runmq-rabbitmq-test
+    user: "999:999" # RabbitMQ default UID:GID
     ports:
       - "5673:5672"
       - "15673:15672"


### PR DESCRIPTION
This PR for run rabbitmq with default UID and GID because when i tried to run `test-e2e.sh` container failed to start but when i run `docker compose up` it's work fine