### PR TITLE
test: deflake resubscribe e2e by polling for fresh consumer

### DIFF
--- a/tests/e2e/RunMQ.resubscribe.e2e.test.ts
+++ b/tests/e2e/RunMQ.resubscribe.e2e.test.ts
@@ -2,7 +2,6 @@ import {RunMQ} from '@src/core/RunMQ';
 import {RabbitMQClientAdapter} from "@src/core/clients/RabbitMQClientAdapter";
 import {Constants} from "@src/core/constants";
 import {ChannelTestHelpers} from "@tests/helpers/ChannelTestHelpers";
-import {RunMQUtils} from "@src/core/utils/RunMQUtils";
 import {MockedRunMQLogger} from "@tests/mocks/MockedRunMQLogger";
 import {RunMQConnectionConfigExample} from "@tests/Examples/RunMQConnectionConfigExample";
 import {RunMQProcessorConfigurationExample} from "@tests/Examples/RunMQProcessorConfigurationExample";
@@ -20,38 +19,73 @@ function authHeader(): string {
     return 'Basic ' + Buffer.from(`${cfg.username}:${cfg.password}`).toString('base64');
 }
 
-async function closeConnectionsForQueue(queueName: string, timeoutMs: number): Promise<number> {
+async function listConsumersForQueue(queueName: string): Promise<ManagementConsumer[]> {
     const cfg = RabbitMQManagementConfigExample.valid();
+    const res = await fetch(`${cfg.url}/api/consumers`, {
+        headers: {Authorization: authHeader()},
+    });
+    if (!res.ok) throw new Error(`list consumers failed: ${res.status}`);
+    const consumers = (await res.json()) as ManagementConsumer[];
+    return consumers.filter((c) => c.queue?.name === queueName);
+}
+
+async function waitForConsumers(queueName: string, expectedCount: number, timeoutMs: number): Promise<ManagementConsumer[]> {
     const deadline = Date.now() + timeoutMs;
-    const closed = new Set<string>();
-
+    let last: ManagementConsumer[] = [];
     while (Date.now() < deadline) {
-        const res = await fetch(`${cfg.url}/api/consumers`, {
-            headers: {Authorization: authHeader()},
-        });
-        if (!res.ok) throw new Error(`list consumers failed: ${res.status}`);
-        const consumers = (await res.json()) as ManagementConsumer[];
-        const targets = consumers.filter((c) => c.queue?.name === queueName);
-
-        if (targets.length > 0) {
-            for (const c of targets) {
-                const connName = c.channel_details?.connection_name;
-                if (connName && !closed.has(connName)) {
-                    const del = await fetch(
-                        `${cfg.url}/api/connections/${encodeURIComponent(connName)}`,
-                        {method: 'DELETE', headers: {Authorization: authHeader()}}
-                    );
-                    if (!del.ok && del.status !== 404) {
-                        throw new Error(`close connection failed: ${del.status}`);
-                    }
-                    closed.add(connName);
-                }
-            }
-            return closed.size;
-        }
+        last = await listConsumersForQueue(queueName);
+        if (last.length >= expectedCount) return last;
         await new Promise((r) => setTimeout(r, 200));
     }
-    return closed.size;
+    return last;
+}
+
+async function closeConnectionsForQueue(queueName: string, timeoutMs: number): Promise<{ closed: Set<string>; consumerTags: Set<string> }> {
+    const cfg = RabbitMQManagementConfigExample.valid();
+    const targets = await waitForConsumers(queueName, 1, timeoutMs);
+    const closed = new Set<string>();
+    const consumerTags = new Set<string>();
+    for (const c of targets) {
+        const connName = c.channel_details?.connection_name;
+        if (connName && !closed.has(connName)) {
+            const del = await fetch(
+                `${cfg.url}/api/connections/${encodeURIComponent(connName)}`,
+                {method: 'DELETE', headers: {Authorization: authHeader()}}
+            );
+            if (!del.ok && del.status !== 404) {
+                throw new Error(`close connection failed: ${del.status}`);
+            }
+            closed.add(connName);
+        }
+        const tag = (c as any).consumer_tag;
+        if (tag) consumerTags.add(tag);
+    }
+    return {closed, consumerTags};
+}
+
+async function waitForFreshConsumer(queueName: string, originalTags: Set<string>, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const consumers = await listConsumersForQueue(queueName);
+        const fresh = consumers.find((c) => {
+            const tag = (c as any).consumer_tag;
+            return tag && !originalTags.has(tag);
+        });
+        if (fresh) return true;
+        await new Promise((r) => setTimeout(r, 200));
+    }
+    return false;
+}
+
+async function waitFor<T>(check: () => T | Promise<T>, predicate: (v: T) => boolean, timeoutMs: number): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    let last: T;
+    do {
+        last = await check();
+        if (predicate(last)) return last;
+        await new Promise((r) => setTimeout(r, 100));
+    } while (Date.now() < deadline);
+    return last!;
 }
 
 describe('RunMQ Consumer Channel Resubscription E2E', () => {
@@ -81,17 +115,24 @@ describe('RunMQ Consumer Channel Resubscription E2E', () => {
             topic,
             MessageTestUtils.buffer(RunMQMessageExample.random())
         );
-        await RunMQUtils.delay(500);
+        await waitFor(
+            () => received.length,
+            (n) => n >= 1,
+            5000
+        );
         expect(received.length).toBe(1);
 
         // Force-close only the connection(s) holding consumers for our queue.
         // Scoping by queue avoids killing unrelated parallel-test connections.
-        const closed = await closeConnectionsForQueue(configuration.name, 5000);
-        expect(closed).toBeGreaterThan(0);
+        const {closed, consumerTags} = await closeConnectionsForQueue(configuration.name, 5000);
+        expect(closed.size).toBeGreaterThan(0);
 
-        // Wait long enough for the rabbitmq-client to reconnect and for our
-        // resubscription to fire (RECONNECT_DELAY is 5s). Add headroom.
-        await RunMQUtils.delay(8000);
+        // Wait until a NEW consumer (different tag from the one we killed) is
+        // registered against the queue — that proves the resubscription
+        // pipeline ran end-to-end. Polling beats fixed sleeps: it cuts the
+        // happy-path delay and removes the slow-CI flake from waiting too short.
+        const resubscribed = await waitForFreshConsumer(configuration.name, consumerTags, 20000);
+        expect(resubscribed).toBe(true);
 
         // Re-acquire a publishing channel; the previous one was closed too.
         const republishChannel = await testingConnection.getChannel();
@@ -101,9 +142,13 @@ describe('RunMQ Consumer Channel Resubscription E2E', () => {
             MessageTestUtils.buffer(RunMQMessageExample.random())
         );
 
-        await RunMQUtils.delay(2000);
+        await waitFor(
+            () => received.length,
+            (n) => n >= 2,
+            5000
+        );
         expect(received.length).toBe(2);
 
         await runMQ.disconnect();
-    }, 30000);
+    }, 40000);
 });


### PR DESCRIPTION
Replace fixed sleeps with management-API polling: capture the original consumer tag before force-closing the connection, then wait for a *different* consumer tag to appear on the queue before publishing the follow-up message. This proves the resubscription pipeline ran end-to-end without depending on RECONNECT_DELAY + rabbitmq-client reconnect happening within an arbitrary deadline — which is the failure mode in slower CI environments. Also poll on received message count instead of fixed waits.