### PR TITLE
refactor: drop RabbitMQMessage UUID defaults; require explicit ids (#31)

### DIFF
--- a/src/core/consumer/RunMQConsumerCreator.ts
+++ b/src/core/consumer/RunMQConsumerCreator.ts
@@ -18,6 +18,7 @@ import {RunMQTTLPolicyManager} from "@src/core/management/Policies/RunMQTTLPolic
 import {RunMQMetadataManager} from "@src/core/management/Policies/RunMQMetadataManager";
 import {RunMQException} from "@src/core/exceptions/RunMQException";
 import {Exceptions} from "@src/core/exceptions/Exceptions";
+import {RunMQUtils} from "@src/core/utils/RunMQUtils";
 
 export class RunMQConsumerCreator {
     private ttlPolicyManager: RunMQTTLPolicyManager;
@@ -72,8 +73,11 @@ export class RunMQConsumerCreator {
             if (!msg) return;
             const rabbitmqMessage = new RabbitMQMessage(
                 msg.content.toString(),
-                msg.properties.messageId,
-                msg.properties.correlationId,
+                // Synthesize ids when an external (non-RunMQ) publisher did
+                // not set the AMQP messageId/correlationId — keeps log tracing
+                // consistent for cross-tenant queues.
+                msg.properties.messageId ?? RunMQUtils.generateUUID(),
+                msg.properties.correlationId ?? RunMQUtils.generateUUID(),
                 consumerChannel,
                 msg,
                 msg.properties.headers,

--- a/src/core/message/RabbitMQMessage.ts
+++ b/src/core/message/RabbitMQMessage.ts
@@ -1,4 +1,3 @@
-import {RunMQUtils} from "@src/core/utils/RunMQUtils";
 import {RabbitMQMessageProperties} from "@src/core/message/RabbitMQMessageProperties";
 import {AMQPMessage} from "@src/core/message/AmqpMessage";
 import {AMQPChannel} from "@src/types";
@@ -6,8 +5,8 @@ import {AMQPChannel} from "@src/types";
 export class RabbitMQMessage {
     constructor(
         readonly message: any,
-        readonly id: string = RunMQUtils.generateUUID(),
-        readonly correlationId: string = RunMQUtils.generateUUID(),
+        readonly id: string,
+        readonly correlationId: string,
         readonly channel: AMQPChannel,
         readonly amqpMessage: AMQPMessage = null,
         readonly headers: Record<string, any> = {}) {


### PR DESCRIPTION
TS-evaluated default param expressions are lazy, so the existing defaults were not a perf concern in the hot path — RunMQ-published messages always carry messageId/correlationId on AMQP properties, so the defaults never executed. The only callsite where they could fire was the consumer-side construction in RunMQConsumerCreator when an external (non-RunMQ) publisher omits those AMQP properties.

Make the constructor contract explicit: id and correlationId are now required. Move the synthesize-on-missing fallback to the consumer construction site, where it's actually meaningful (keeps log tracing consistent for cross-tenant queues).