### PR TITLE
perf: stop logging full message payload by default (#27)

### DIFF
--- a/src/core/RunMQ.ts
+++ b/src/core/RunMQ.ts
@@ -30,7 +30,7 @@ export class RunMQ {
             maxReconnectAttempts: config.maxReconnectAttempts ?? DEFAULTS.MAX_RECONNECT_ATTEMPTS,
         };
         this.client = new RabbitMQClientAdapter(this.config, this.logger);
-        this.consumer = new RunMQConsumerCreator(this.client, this.logger, this.config.management);
+        this.consumer = new RunMQConsumerCreator(this.client, this.logger, this.config.management, this.config.logFullMessagePayload);
     }
 
     /**
@@ -67,17 +67,24 @@ export class RunMQ {
             throw new RunMQException(Exceptions.NOT_INITIALIZED, {});
         }
         RunMQUtils.assertRecord(message);
+        const messageId = RunMQUtils.generateUUID();
         this.publisher.publish(topic,
             RabbitMQMessage.from(
                 message,
                 this.publishChannel,
-                new RabbitMQMessageProperties(RunMQUtils.generateUUID(), correlationId)
+                new RabbitMQMessageProperties(messageId, correlationId)
             )
         );
+        // Avoid capturing the payload by default — for megabyte-sized
+        // bodies at high throughput the structured-log JSON.stringify
+        // dominates allocations even when the level filters the line out.
+        // correlationId/messageId let you join with publisher- or
+        // consumer-side logs and look up the body in the broker or DLQ.
         this.logger.info(`Published message`, {
             topic,
             correlationId,
-            message,
+            messageId,
+            ...(this.config.logFullMessagePayload ? {message} : {}),
         });
     }
 

--- a/src/core/consumer/RunMQConsumerCreator.ts
+++ b/src/core/consumer/RunMQConsumerCreator.ts
@@ -27,7 +27,8 @@ export class RunMQConsumerCreator {
     constructor(
         private client: AMQPClient,
         private logger: RunMQLogger,
-        managementConfig?: RabbitMQManagementConfig
+        managementConfig?: RabbitMQManagementConfig,
+        private logFullMessagePayload: boolean = false,
     ) {
         this.ttlPolicyManager = new RunMQTTLPolicyManager(logger, managementConfig);
         this.metadataManager = new RunMQMetadataManager(logger, managementConfig);
@@ -93,10 +94,12 @@ export class RunMQConsumerCreator {
                                         consumerConfiguration.processorConfig,
                                         new DefaultDeserializer<T>()
                                     ),
-                                    this.logger
+                                    this.logger,
+                                    this.logFullMessagePayload,
                                 ),
                                 consumerConfiguration.processorConfig,
-                                this.logger
+                                this.logger,
+                                this.logFullMessagePayload,
                             ),
                             this.logger
                         ),

--- a/src/core/consumer/processors/RunMQFailureLoggerProcessor.ts
+++ b/src/core/consumer/processors/RunMQFailureLoggerProcessor.ts
@@ -3,7 +3,11 @@ import {RabbitMQMessage} from "@src/core/message/RabbitMQMessage";
 import {RunMQLogger} from "@src/core/logging/RunMQLogger";
 
 export class RunMQFailureLoggerProcessor implements RunMQConsumer {
-    constructor(private consumer: RunMQConsumer, private logger: RunMQLogger) {
+    constructor(
+        private consumer: RunMQConsumer,
+        private logger: RunMQLogger,
+        private logFullMessagePayload: boolean = false,
+    ) {
     }
 
     public async consume(message: RabbitMQMessage) {
@@ -11,7 +15,9 @@ export class RunMQFailureLoggerProcessor implements RunMQConsumer {
             return await this.consumer.consume(message);
         } catch (e) {
             this.logger.error('Message processing failed', {
-                    message: message.message,
+                    correlationId: message.correlationId,
+                    messageId: message.id,
+                    ...(this.logFullMessagePayload ? {message: message.message} : {}),
                 },
                 e instanceof Error ? e.stack : undefined);
             throw e;

--- a/src/core/consumer/processors/RunMQRetriesCheckerProcessor.ts
+++ b/src/core/consumer/processors/RunMQRetriesCheckerProcessor.ts
@@ -11,6 +11,7 @@ export class RunMQRetriesCheckerProcessor implements RunMQConsumer {
         private readonly consumer: RunMQConsumer,
         private readonly config: RunMQProcessorConfiguration,
         private readonly logger: RunMQLogger,
+        private readonly logFullMessagePayload: boolean = false,
     ) {
     }
 
@@ -36,9 +37,11 @@ export class RunMQRetriesCheckerProcessor implements RunMQConsumer {
     private logMaxRetriesReached(message: RabbitMQMessage) {
         this.logger.error(
             `Message reached maximum attempts. Moving to dead-letter queue.`, {
-                message: message.message,
+                correlationId: message.correlationId,
+                messageId: message.id,
                 attempts: this.getRejectionCount(message),
                 max: this.maxAttempts,
+                ...(this.logFullMessagePayload ? {message: message.message} : {}),
             }
         );
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,6 +220,22 @@ export interface RunMQConnectionConfig {
         username: string;
         password: string;
     };
+    /**
+     * If true, RunMQ includes the full message payload in info/error log
+     * lines that mention a message (publish success, per-attempt failure,
+     * max-retries-reached). Off by default — capturing megabyte-sized
+     * payloads on every log call allocates GB/s of refs that structured-log
+     * transports JSON.stringify even when the level filters the line out.
+     *
+     * With this flag off, every relevant log line still carries the
+     * `correlationId` and `messageId`. Use those to look up the body in
+     * the broker (retry-delay queue) or in the DLQ (where the original
+     * envelope is preserved), or to join with publisher-side logs.
+     *
+     * Turn it on in development or when chasing a specific bug; leave it
+     * off in production.
+     */
+    logFullMessagePayload?: boolean;
 }
 
 export type SchemaFailureStrategy = 'dlq'

--- a/tests/unit/core/RunMQ.test.ts
+++ b/tests/unit/core/RunMQ.test.ts
@@ -129,7 +129,8 @@ describe('RunMQ Unit Tests', () => {
             expect(mockConsumerCreator).toHaveBeenCalledWith(
                 expect.any(RabbitMQClientAdapter),
                 expect.any(Object),
-                undefined
+                undefined,
+                undefined,
             );
             expect(mockConsumerCreator.prototype.createConsumer).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -159,6 +160,41 @@ describe('RunMQ Unit Tests', () => {
             runMQ.publish('test.topic', MessageExample.person());
 
             expect(mockPublisher.publish).toHaveBeenCalledWith('test.topic', expect.any(Object));
+        });
+
+        it('should not include the payload in the publish info log by default', async () => {
+            setupSuccessfulClientMock();
+            setupPublisherMock();
+            (RunMQUtils.generateUUID as jest.Mock).mockReturnValue('msg-uuid');
+
+            const runMQ = await RunMQ.start(validConfig, MockedRunMQLogger);
+            runMQ.publish('test.topic', MessageExample.person(), 'corr-1');
+
+            expect(MockedRunMQLogger.info).toHaveBeenCalledWith('Published message', {
+                topic: 'test.topic',
+                correlationId: 'corr-1',
+                messageId: 'msg-uuid',
+            });
+        });
+
+        it('should include the payload in the publish info log when logFullMessagePayload is true', async () => {
+            setupSuccessfulClientMock();
+            setupPublisherMock();
+            (RunMQUtils.generateUUID as jest.Mock).mockReturnValue('msg-uuid');
+
+            const runMQ = await RunMQ.start(
+                {...validConfig, logFullMessagePayload: true},
+                MockedRunMQLogger,
+            );
+            const payload = MessageExample.person();
+            runMQ.publish('test.topic', payload, 'corr-1');
+
+            expect(MockedRunMQLogger.info).toHaveBeenCalledWith('Published message', {
+                topic: 'test.topic',
+                correlationId: 'corr-1',
+                messageId: 'msg-uuid',
+                message: payload,
+            });
         });
     });
 

--- a/tests/unit/core/consumer/processors/RunMQFailureLoggerProcessor.test.ts
+++ b/tests/unit/core/consumer/processors/RunMQFailureLoggerProcessor.test.ts
@@ -6,11 +6,24 @@ import {MockedRabbitMQMessage} from "@tests/mocks/MockedRabbitMQMessage";
 describe('RunMQFailureLoggerProcessor', () => {
     const mockedRunMQConsumer = new MockedThrowableRabbitMQConsumer()
 
-    it("should log error and rethrow when consumer throws", async () => {
+    it("should log error with correlationId/messageId (and not the payload) by default", async () => {
         const processor = new RunMQFailureLoggerProcessor(mockedRunMQConsumer, MockedRunMQLogger);
         await expect(processor.consume(MockedRabbitMQMessage)).rejects.toThrow("Mocked error");
 
         expect(MockedRunMQLogger.error).toHaveBeenCalledWith('Message processing failed', {
+                correlationId: MockedRabbitMQMessage.correlationId,
+                messageId: MockedRabbitMQMessage.id,
+            },
+            expect.any(String));
+    });
+
+    it("should include the payload when logFullMessagePayload is true", async () => {
+        const processor = new RunMQFailureLoggerProcessor(mockedRunMQConsumer, MockedRunMQLogger, true);
+        await expect(processor.consume(MockedRabbitMQMessage)).rejects.toThrow("Mocked error");
+
+        expect(MockedRunMQLogger.error).toHaveBeenCalledWith('Message processing failed', {
+                correlationId: MockedRabbitMQMessage.correlationId,
+                messageId: MockedRabbitMQMessage.id,
                 message: MockedRabbitMQMessage.message,
             },
             expect.any(String));

--- a/tests/unit/core/consumer/processors/RunMQRetriesCheckerProcessor.test.ts
+++ b/tests/unit/core/consumer/processors/RunMQRetriesCheckerProcessor.test.ts
@@ -30,7 +30,8 @@ describe('RunMQRetriesCheckerProcessor', () => {
         await processor.consume(message)
 
         expect(MockedRunMQLogger.error).toHaveBeenCalledWith(`Message reached maximum attempts. Moving to dead-letter queue.`, {
-            message: message.message,
+            correlationId: message.correlationId,
+            messageId: message.id,
             attempts: 3,
             max: 3,
         });
@@ -69,7 +70,8 @@ describe('RunMQRetriesCheckerProcessor - acknowledgeMessage', () => {
         await expect(processor.consume(message)).resolves.toBe(false);
 
         expect(MockedRunMQLogger.error).toHaveBeenCalledWith(`Message reached maximum attempts. Moving to dead-letter queue.`, {
-            message: message.message,
+            correlationId: message.correlationId,
+            messageId: message.id,
             attempts: 3,
             max: 3,
         });


### PR DESCRIPTION
Three log sites used to capture the entire message body — RunMQ.publish on success, RunMQFailureLoggerProcessor on every per-attempt failure, and RunMQRetriesCheckerProcessor.logMaxRetriesReached on DLQ-bound messages. For megabyte-sized payloads at high throughput, structured-log transports JSON.stringify those refs even when the level filters the line out, allocating GB/s of garbage the GC has to reclaim.

Drop the payload from those log lines and add correlationId + messageId instead — both are cheap strings RunMQ already attaches to every message. The actual body is still recoverable via the broker (retry queues hold mid-flight messages; DLQ holds the original AMQP body verbatim per #25), keyed by those same ids.

Add an opt-in RunMQConnectionConfig.logFullMessagePayload flag for debug scenarios where you want the body inline.