### PR TITLE
docs: add usePublisherConfirms to README connection config table

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This is the hook you want when you're piping logs into Winston, Bunyan, Datadog,
 | `url` | `string` | — | The URL of the RabbitMQ server. |
 | `reconnectDelay` | `number` | `5000` | Delay in milliseconds before attempting to reconnect after a disconnection. |
 | `maxReconnectAttempts` | `number` | `5` | Maximum number of reconnection attempts. |
+| `usePublisherConfirms` | `boolean` | `true` | Enable RabbitMQ publisher confirms on the user publish channel. When `true`, `publish()` resolves only after the broker acks the message and rejects on broker error. Set to `false` for fire-and-forget publishing. _Available in 2.x._ |
 | `management` | `ManagementConfiguration` | — | RabbitMQ management API configuration. |
 
 ---


### PR DESCRIPTION
Reflects the 2.x publisher confirms default in the README's reference table — the Quick Start prose already covered it but the table did not.